### PR TITLE
rubocopの追加と、boards indexをトップ表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,7 @@ gem "jbuilder"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 
-gem 'devise'
-
+gem "devise"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,5 +1,3 @@
 class Board < ApplicationRecord
-
   belongs_to :user
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,4 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :boards
-
 end

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,2 +1,13 @@
 <h1>Boards#index</h1>
 <p>Find me in app/views/boards/index.html.erb</p>
+
+<%= link_to "新規登録", new_user_registration_path %>
+<%= link_to "ログイン", new_user_session_path %>
+
+<%= link_to "ログアウト", destroy_user_session_path, data: { method: 'delete' } %>
+
+
+
+
+
+

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -36,7 +36,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [ :email ]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [ :email ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [ :http_auth ]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX


### PR DESCRIPTION
・rubocopでの文法修正
bundle exec rubocop
rubocop -a

・hamlに書き換え
gem 'hamlit'
gem 'erb2haml'
rake haml:replace_erbs
エラーが解消できず、hamlにするのはいったん諦める

・sign_upとsign_inのリンクをトップに追加